### PR TITLE
chore: update recipe to refresh conda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   skip: true  # [py>=314]
 
 requirements:


### PR DESCRIPTION
Since the update, ansys-pythonnet is not available on conda. Hopefully, going through another build would solve this issue.
